### PR TITLE
remove namespace from vulnerabilities under layer's features (duplicated info)

### DIFF
--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -61,7 +61,6 @@ func LayerFromDatabaseModel(dbLayer database.Layer, withFeatures, withVulnerabil
 			for _, dbVuln := range dbFeatureVersion.AffectedBy {
 				vuln := Vulnerability{
 					Name:        dbVuln.Name,
-					Namespace:   dbVuln.Namespace.Name,
 					Description: dbVuln.Description,
 					Severity:    string(dbVuln.Severity),
 					Metadata:    dbVuln.Metadata,


### PR DESCRIPTION
Before:

```
            {
                "Name": "gcc-4.9",
                "Namespace": "debian:8",
                "Version": "4.9.2-10",
                "Vulnerabilities": [
                    {
                        "Description": "The std::random_device class in libstdc++ in the GNU Compiler Collection (aka GCC) before 4.9.4 does not properly handle short reads from blocking sources, which makes it easier for context-dependent attackers to predict the random values via unspecified vectors.",
                        "Metadata": {
                            "NVD": {
                                "CVSSv2": {
                                    "Score": 5,
                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N"
                                }
                            }
                        },
                        "Name": "CVE-2015-5276",
                        "Namespace": "debian:8",
                        "Severity": "Medium"
                    }
                ]
            },
```

After:

```
            {
                "Name": "gcc-4.9",
                "Namespace": "debian:8",
                "Version": "4.9.2-10",
                "Vulnerabilities": [
                    {
                        "Description": "The std::random_device class in libstdc++ in the GNU Compiler Collection (aka GCC) before 4.9.4 does not properly handle short reads from blocking sources, which makes it easier for context-dependent attackers to predict the random values via unspecified vectors.",
                        "Metadata": {
                            "NVD": {
                                "CVSSv2": {
                                    "Score": 5,
                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N"
                                }
                            }
                        },
                        "Name": "CVE-2015-5276",
                        "Severity": "Medium"
                    }
                ]
            },
```
